### PR TITLE
get_formatted_chrm: don't crash after "chrX"

### DIFF
--- a/python/createTHetAExomeInput.py
+++ b/python/createTHetAExomeInput.py
@@ -226,10 +226,10 @@ def get_formatted_chrm(chr_string):
 
 	#Check for X
 	if chr_string.lower() == "x":
-		chr_string = 23
+		return 23
 
 	if chr_string.lower() == "y":
-		chr_string = 24
+		return 24
 
 	if chr_string.isdigit():
 		return int(chr_string)


### PR DESCRIPTION
After encountering "x" or similar, chr_string becomes an int and the next test for "y" crashes because ints don't have a "lower" method. Fix: return immediately, don't keep going after "x".
