### PR TITLE
fixed error in path creation for BAF output

### DIFF
--- a/python/FileIO.py
+++ b/python/FileIO.py
@@ -682,7 +682,7 @@ def write_out_NLL_result(directory, prefix, results, best=True):
     filename = prefix + ".results"
     BAFfilename = prefix + ".BAF.NLL.results"
     path = os.path.join(directory, filename)
-    BAFpath = os.path.join(directory, filename)
+    BAFpath = os.path.join(directory, BAFfilename)
 
     print "Writing results file to", path
 


### PR DESCRIPTION
This was causing the output which should have been in `.BAF.NLL.results` to stomp on top of <>.results.  This caused problems for other tools like CNVKit which assert the headers in `.results` and refused to operate when it saw the extra header in `.BAF.NLL.results`